### PR TITLE
Refine niche model docs and API mapping

### DIFF
--- a/api/routers/niches.py
+++ b/api/routers/niches.py
@@ -41,16 +41,27 @@ def get_agent():
 
 def convert_mcp_niche_to_api(mcp_niche: Dict[str, Any]) -> NicheData:
     """Convert MCP agent niche data to API response format."""
+    trend_data = mcp_niche.get("trend_analysis_data") or {}
+    if not isinstance(trend_data, dict):
+        trend_direction = getattr(trend_data, "trend_direction", "stable")
+    else:
+        trend_direction = trend_data.get("trend_direction", "stable")
+
+    market_size_score = float(mcp_niche.get("market_size_score", 0))
+    search_volume = int(market_size_score * 100)
+
     return NicheData(
-        name=mcp_niche.get('name', ''),
-        score=float(mcp_niche.get('profitability_score', 0)),
-        competition_level=mcp_niche.get('competition_level', 'unknown'),
-        search_volume=int(mcp_niche.get('search_volume', 0)),
-        trend_direction=mcp_niche.get('trend_direction', 'stable'),
-        keywords=mcp_niche.get('keywords', []),
-        estimated_revenue=mcp_niche.get('estimated_revenue'),
-        seasonality=mcp_niche.get('seasonality'),
-        barriers_to_entry=mcp_niche.get('barriers_to_entry', [])
+        name=mcp_niche.get("primary_keyword", mcp_niche.get("name", "")),
+        score=float(mcp_niche.get("profitability_score_numeric", mcp_niche.get("profitability_score", 0))),
+        competition_level=mcp_niche.get("competition_level", "unknown"),
+        profitability_tier=mcp_niche.get("profitability_tier", "medium"),
+        risk_level=mcp_niche.get("risk_level", "medium"),
+        search_volume=search_volume,
+        trend_direction=trend_direction,
+        keywords=mcp_niche.get("keywords", []),
+        estimated_revenue=mcp_niche.get("estimated_revenue"),
+        seasonality=mcp_niche.get("seasonal_factors"),
+        barriers_to_entry=mcp_niche.get("barriers_to_entry", [])
     )
 
 

--- a/src/kdp_strategist/models/niche_model.py
+++ b/src/kdp_strategist/models/niche_model.py
@@ -67,8 +67,6 @@ class Niche:
         keywords: List of relevant keywords for the niche
         competition_score: Competition intensity (0-100, lower is better)
         profitability_score: Profit potential (0-100, higher is better)
-        trend_direction: Overall trend direction
-        estimated_monthly_searches: Estimated search volume per month
         top_competitors: List of top competitor ASINs
         recommended_price_range: Suggested pricing range (min, max)
         content_gaps: Identified gaps in existing content


### PR DESCRIPTION
## Summary
- update Niche dataclass documentation to remove obsolete fields
- derive search volume and trend direction in API conversion helper

## Testing
- `pytest -q`
- `python -m compileall -q src api`


------
https://chatgpt.com/codex/tasks/task_e_68767f03317c832597e60f5f506f1f1b