### PR TITLE
Refactor scoring thresholds into constants

### DIFF
--- a/src/kdp_strategist/agent/tools/competitor_analysis.py
+++ b/src/kdp_strategist/agent/tools/competitor_analysis.py
@@ -70,16 +70,24 @@ class MarketAnalysis:
 
 class CompetitorAnalyzer:
     """Core analyzer for competitor data and market insights."""
-    
+
     # BSR to sales estimation (rough approximations)
+    BSR_LEVEL_1 = 1
+    BSR_LEVEL_10 = 10
+    BSR_LEVEL_100 = 100
+    BSR_LEVEL_1000 = 1000
+    BSR_LEVEL_10000 = 10000
+    BSR_LEVEL_100000 = 100000
+    BSR_LEVEL_1000000 = 1000000
+
     BSR_SALES_MAPPING = {
-        1: 3000,
-        10: 1500,
-        100: 300,
-        1000: 50,
-        10000: 10,
-        100000: 2,
-        1000000: 0.5
+        BSR_LEVEL_1: 3000,
+        BSR_LEVEL_10: 1500,
+        BSR_LEVEL_100: 300,
+        BSR_LEVEL_1000: 50,
+        BSR_LEVEL_10000: 10,
+        BSR_LEVEL_100000: 2,
+        BSR_LEVEL_1000000: 0.5,
     }
     
     @classmethod
@@ -94,7 +102,13 @@ class CompetitorAnalyzer:
                 return sales
         
         # For very high BSR (low sales)
-        return max(1, int(cls.BSR_SALES_MAPPING[1000000] * (1000000 / bsr)))
+        return max(
+            1,
+            int(
+                cls.BSR_SALES_MAPPING[cls.BSR_LEVEL_1000000]
+                * (cls.BSR_LEVEL_1000000 / bsr)
+            ),
+        )
     
     @classmethod
     def calculate_price_stability(cls, price_history: List[Tuple[datetime, float]]) -> float:

--- a/src/kdp_strategist/agent/tools/niche_discovery.py
+++ b/src/kdp_strategist/agent/tools/niche_discovery.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 class NicheScorer:
     """Scoring engine for niche profitability analysis."""
-    
+
     # Scoring weights
     WEIGHTS = {
         "trend_score": 0.25,
@@ -42,6 +42,18 @@ class NicheScorer:
         "seasonality_score": 0.15,
         "content_gap_score": 0.10
     }
+
+    # Competition scoring thresholds
+    LOW_COMPETITION_THRESHOLD = 10
+    MEDIUM_COMPETITION_THRESHOLD = 50
+    HIGH_COMPETITION_THRESHOLD = 100
+
+    HIGH_REVIEW_THRESHOLD = 1000
+    MEDIUM_REVIEW_THRESHOLD = 100
+    LOW_REVIEW_THRESHOLD = 10
+
+    LOW_RATING_THRESHOLD = 3.5
+    HIGH_RATING_THRESHOLD = 4.5
     
     @classmethod
     def calculate_profitability_score(cls, niche_data: Dict[str, Any]) -> float:
@@ -101,27 +113,27 @@ class NicheScorer:
         # Base score inversely related to competition
         if competitor_count == 0:
             base_score = 100
-        elif competitor_count < 10:
+        elif competitor_count < cls.LOW_COMPETITION_THRESHOLD:
             base_score = 90
-        elif competitor_count < 50:
+        elif competitor_count < cls.MEDIUM_COMPETITION_THRESHOLD:
             base_score = 70
-        elif competitor_count < 100:
+        elif competitor_count < cls.HIGH_COMPETITION_THRESHOLD:
             base_score = 50
         else:
             base_score = 30
-        
+
         # Adjust for review saturation
-        if avg_reviews > 1000:
+        if avg_reviews > cls.HIGH_REVIEW_THRESHOLD:
             base_score *= 0.6  # High review saturation
-        elif avg_reviews > 100:
+        elif avg_reviews > cls.MEDIUM_REVIEW_THRESHOLD:
             base_score *= 0.8
-        elif avg_reviews < 10:
+        elif avg_reviews < cls.LOW_REVIEW_THRESHOLD:
             base_score *= 1.2  # Low review saturation = opportunity
-        
+
         # Adjust for rating quality
-        if avg_rating < 3.5:
+        if avg_rating < cls.LOW_RATING_THRESHOLD:
             base_score *= 1.3  # Poor ratings = opportunity
-        elif avg_rating > 4.5:
+        elif avg_rating > cls.HIGH_RATING_THRESHOLD:
             base_score *= 0.9  # High ratings = strong competition
         
         return min(100, base_score)

--- a/src/kdp_strategist/agent/tools/stress_testing.py
+++ b/src/kdp_strategist/agent/tools/stress_testing.py
@@ -93,72 +93,89 @@ class StressTestReport:
 class StressTester:
     """Core stress testing engine."""
     
+    # Default parameters for each stress scenario
+    MARKET_SATURATION_DEFAULT = StressTestParameters(
+        scenario=StressScenario.MARKET_SATURATION,
+        severity=0.7,
+        duration_months=6,
+        recovery_months=12,
+        probability=0.3,
+        description="Market becomes oversaturated with competitors",
+    )
+
+    ECONOMIC_DOWNTURN_DEFAULT = StressTestParameters(
+        scenario=StressScenario.ECONOMIC_DOWNTURN,
+        severity=0.6,
+        duration_months=8,
+        recovery_months=18,
+        probability=0.2,
+        description="Economic recession reduces consumer spending",
+    )
+
+    COMPETITIVE_FLOODING_DEFAULT = StressTestParameters(
+        scenario=StressScenario.COMPETITIVE_FLOODING,
+        severity=0.8,
+        duration_months=4,
+        recovery_months=8,
+        probability=0.4,
+        description="Sudden influx of new competitors",
+    )
+
+    SEASONAL_CRASH_DEFAULT = StressTestParameters(
+        scenario=StressScenario.SEASONAL_CRASH,
+        severity=0.9,
+        duration_months=3,
+        recovery_months=6,
+        probability=0.5,
+        description="Severe seasonal demand drop",
+    )
+
+    PLATFORM_CHANGES_DEFAULT = StressTestParameters(
+        scenario=StressScenario.PLATFORM_CHANGES,
+        severity=0.5,
+        duration_months=3,
+        recovery_months=9,
+        probability=0.3,
+        description="Amazon algorithm or policy changes",
+    )
+
+    TREND_REVERSAL_DEFAULT = StressTestParameters(
+        scenario=StressScenario.TREND_REVERSAL,
+        severity=0.8,
+        duration_months=12,
+        recovery_months=24,
+        probability=0.25,
+        description="Major trend reversal or consumer preference shift",
+    )
+
+    CONSUMER_SHIFT_DEFAULT = StressTestParameters(
+        scenario=StressScenario.CONSUMER_SHIFT,
+        severity=0.6,
+        duration_months=9,
+        recovery_months=15,
+        probability=0.35,
+        description="Consumer behavior and preferences change",
+    )
+
+    SUPPLY_CHAIN_DISRUPTION_DEFAULT = StressTestParameters(
+        scenario=StressScenario.SUPPLY_CHAIN_DISRUPTION,
+        severity=0.4,
+        duration_months=2,
+        recovery_months=4,
+        probability=0.15,
+        description="Supply chain or production disruptions",
+    )
+
     # Stress test scenarios with default parameters
     DEFAULT_SCENARIOS = {
-        StressScenario.MARKET_SATURATION: StressTestParameters(
-            scenario=StressScenario.MARKET_SATURATION,
-            severity=0.7,
-            duration_months=6,
-            recovery_months=12,
-            probability=0.3,
-            description="Market becomes oversaturated with competitors"
-        ),
-        StressScenario.ECONOMIC_DOWNTURN: StressTestParameters(
-            scenario=StressScenario.ECONOMIC_DOWNTURN,
-            severity=0.6,
-            duration_months=8,
-            recovery_months=18,
-            probability=0.2,
-            description="Economic recession reduces consumer spending"
-        ),
-        StressScenario.COMPETITIVE_FLOODING: StressTestParameters(
-            scenario=StressScenario.COMPETITIVE_FLOODING,
-            severity=0.8,
-            duration_months=4,
-            recovery_months=8,
-            probability=0.4,
-            description="Sudden influx of new competitors"
-        ),
-        StressScenario.SEASONAL_CRASH: StressTestParameters(
-            scenario=StressScenario.SEASONAL_CRASH,
-            severity=0.9,
-            duration_months=3,
-            recovery_months=6,
-            probability=0.5,
-            description="Severe seasonal demand drop"
-        ),
-        StressScenario.PLATFORM_CHANGES: StressTestParameters(
-            scenario=StressScenario.PLATFORM_CHANGES,
-            severity=0.5,
-            duration_months=3,
-            recovery_months=9,
-            probability=0.3,
-            description="Amazon algorithm or policy changes"
-        ),
-        StressScenario.TREND_REVERSAL: StressTestParameters(
-            scenario=StressScenario.TREND_REVERSAL,
-            severity=0.8,
-            duration_months=12,
-            recovery_months=24,
-            probability=0.25,
-            description="Major trend reversal or consumer preference shift"
-        ),
-        StressScenario.CONSUMER_SHIFT: StressTestParameters(
-            scenario=StressScenario.CONSUMER_SHIFT,
-            severity=0.6,
-            duration_months=9,
-            recovery_months=15,
-            probability=0.35,
-            description="Consumer behavior and preferences change"
-        ),
-        StressScenario.SUPPLY_CHAIN_DISRUPTION: StressTestParameters(
-            scenario=StressScenario.SUPPLY_CHAIN_DISRUPTION,
-            severity=0.4,
-            duration_months=2,
-            recovery_months=4,
-            probability=0.15,
-            description="Supply chain or production disruptions"
-        )
+        StressScenario.MARKET_SATURATION: MARKET_SATURATION_DEFAULT,
+        StressScenario.ECONOMIC_DOWNTURN: ECONOMIC_DOWNTURN_DEFAULT,
+        StressScenario.COMPETITIVE_FLOODING: COMPETITIVE_FLOODING_DEFAULT,
+        StressScenario.SEASONAL_CRASH: SEASONAL_CRASH_DEFAULT,
+        StressScenario.PLATFORM_CHANGES: PLATFORM_CHANGES_DEFAULT,
+        StressScenario.TREND_REVERSAL: TREND_REVERSAL_DEFAULT,
+        StressScenario.CONSUMER_SHIFT: CONSUMER_SHIFT_DEFAULT,
+        StressScenario.SUPPLY_CHAIN_DISRUPTION: SUPPLY_CHAIN_DISRUPTION_DEFAULT,
     }
     
     @classmethod


### PR DESCRIPTION
## Summary
- refactor competition scoring thresholds into named constants
- define BSR level constants and use them in CompetitorAnalyzer
- expose default stress test parameters as named constants

## Testing
- `python -m compileall -q src && echo "compile ok"`

------
https://chatgpt.com/codex/tasks/task_e_68767f146398832597d6fc4c828f9634