### PR TITLE
Use RiskLevel enum in StressTestingResponse

### DIFF
--- a/api/models/responses.py
+++ b/api/models/responses.py
@@ -157,7 +157,7 @@ class StressTestingResponse(BaseModel):
     status: str = Field(default="success", description="Response status")
     niche: str = Field(..., description="Tested niche")
     overall_resilience: float = Field(..., description="Overall resilience score (0-100)")
-    risk_level: str = Field(..., description="Risk level: low, medium, high")
+    risk_level: RiskLevel = Field(..., description="Risk level: low, medium, high")
     scenarios: List[StressTestScenario] = Field(..., description="Stress test scenarios")
     analysis_metadata: AnalysisMetadata = Field(..., description="Analysis metadata")
     charts: List[ChartData] = Field(default=[], description="Visualization data")


### PR DESCRIPTION
## Summary
- use the new `RiskLevel` enum for `StressTestingResponse.risk_level`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68767f6558608325a1ebd7fad2bd173f