### PR TITLE
Add TargetAudience enum

### DIFF
--- a/src/kdp_strategist/models/__init__.py
+++ b/src/kdp_strategist/models/__init__.py
@@ -9,7 +9,7 @@ All models include validation, serialization, and utility methods.
 """
 
 from .niche_model import Niche, NicheCategory
-from .listing_model import KDPListing, ListingCategory
+from .listing_model import KDPListing, ListingCategory, ContentType, TargetAudience
 from .trend_model import TrendAnalysis, TrendDirection, SeasonalPattern
 
 __all__ = [
@@ -17,6 +17,8 @@ __all__ = [
     "NicheCategory",
     "KDPListing",
     "ListingCategory",
+    "ContentType",
+    "TargetAudience",
     "TrendAnalysis",
     "TrendDirection",
     "SeasonalPattern",

--- a/src/kdp_strategist/models/listing_model.py
+++ b/src/kdp_strategist/models/listing_model.py
@@ -31,6 +31,17 @@ class ContentType(Enum):
     DRAMA = "Drama"
 
 
+class TargetAudience(Enum):
+    """Common audience segments for KDP listings."""
+    CHILDREN = "children"
+    TEENS = "teens"
+    ADULTS = "adults"
+    SENIORS = "seniors"
+    PROFESSIONALS = "professionals"
+    STUDENTS = "students"
+    GENERAL = "general"
+
+
 @dataclass
 class KDPListing:
     """Represents an optimized book listing for Amazon KDP.
@@ -67,7 +78,7 @@ class KDPListing:
     categories: List[str] = field(default_factory=list)  # Primary + secondary
     
     # Target market
-    target_audience: str = ""
+    target_audience: TargetAudience = TargetAudience.GENERAL
     unique_selling_points: List[str] = field(default_factory=list)
     
     # Content planning
@@ -346,7 +357,7 @@ class KDPListing:
             "description": self.description,
             "keywords": self.keywords,
             "categories": self.categories,
-            "target_audience": self.target_audience,
+            "target_audience": self.target_audience.value,
             "unique_selling_points": self.unique_selling_points,
             "estimated_page_count": self.estimated_page_count,
             "suggested_price": self.suggested_price,
@@ -387,6 +398,12 @@ class KDPListing:
             "is_optimized", "character_counts", "seo_strength", "full_title"
         }
         filtered_data = {k: v for k, v in data.items() if k not in computed_fields}
+
+        if "target_audience" in filtered_data and isinstance(filtered_data["target_audience"], str):
+            try:
+                filtered_data["target_audience"] = TargetAudience(filtered_data["target_audience"])
+            except ValueError:
+                filtered_data["target_audience"] = TargetAudience.GENERAL
         
         return cls(**filtered_data)
     


### PR DESCRIPTION
## Summary
- add `TargetAudience` enum in `listing_model`
- update `KDPListing` to use the new enum
- export the new enum via `models.__init__`

## Testing
- `python -m compileall -q src/kdp_strategist/models`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687704cd08a083259633d5ec99e95cbe